### PR TITLE
Added "ps-less process tree way"

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@ Credit: @tomnomnom
 :!ps axuw | grep vim | grep -v grep | awk '{print $2}' | xargs kill -9
 ```
 
+## The ps-less process tree way
+Credit: @kpumuk
+
+```
+:!grep -P "PPid:\t(\d+)" /proc/$$/status | cut -f2 | xargs kill -9
+```
+
 ## The ps-less way
 Credit: @tomnomnom
 


### PR DESCRIPTION
This is based on the fact that the child process holds the PID of the parent process, which is easily accessible through `/proc/PID/status`.

Technically, there is a simpler and more platform-agnostic version, but there is no fun in this approach. We can still add it for posterity.

```
:!kill -9 $PPID
```