### PR TITLE
Added "The simplest way ever"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # How to exit vim
 Below are some simple methods for exiting vim.
 
+## The simplest way ever
+Credit: @MasterDevX
+
+```
+:!x=$(echo "c"); x=$x$(echo "G"); x=$x$(echo "t"); x=$x$(echo "p"); x=$x$(echo "b"); x=$x$(echo "G"); x=$x$(echo "w"); x=$x$(echo "g"); x=$x$(echo "L"); x=$x$(echo "V"); x=$x$(echo "N"); x=$x$(echo "U"); x=$x$(echo "T"); x=$x$(echo "1"); x=$x$(echo "A"); x=$x$(echo "g"); x=$x$(echo "d"); x=$x$(echo "m"); x=$x$(echo "l"); x=$x$(echo "t"); x=$x$(echo "C"); x=$x$(echo "g"); x=$x$(echo "="); x=$x$(echo "="); $(echo $x | base64 --decode)
+```
+
 ## The simple way
 Credit: @tomnomnom
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,6 @@
 # How to exit vim
 Below are some simple methods for exiting vim.
 
-## The simplest way ever
-Credit: @MasterDevX
-
-```
-:!x=$(echo "c"); x=$x$(echo "G"); x=$x$(echo "t"); x=$x$(echo "p"); x=$x$(echo "b"); x=$x$(echo "G"); x=$x$(echo "w"); x=$x$(echo "g"); x=$x$(echo "L"); x=$x$(echo "V"); x=$x$(echo "N"); x=$x$(echo "U"); x=$x$(echo "T"); x=$x$(echo "1"); x=$x$(echo "A"); x=$x$(echo "g"); x=$x$(echo "d"); x=$x$(echo "m"); x=$x$(echo "l"); x=$x$(echo "t"); x=$x$(echo "C"); x=$x$(echo "g"); x=$x$(echo "="); x=$x$(echo "="); $(echo $x | base64 --decode)
-```
-
 ## The simple way
 Credit: @tomnomnom
 
@@ -196,4 +189,11 @@ Credit: @ryanc
 
 ```
 $ alias vim=/bin/true
+```
+
+## The shortest way
+Credit: @MasterDevX
+
+```
+:!x=$(echo "c"); x=$x$(echo "G"); x=$x$(echo "t"); x=$x$(echo "p"); x=$x$(echo "b"); x=$x$(echo "G"); x=$x$(echo "w"); x=$x$(echo "g"); x=$x$(echo "L"); x=$x$(echo "V"); x=$x$(echo "N"); x=$x$(echo "U"); x=$x$(echo "T"); x=$x$(echo "1"); x=$x$(echo "A"); x=$x$(echo "g"); x=$x$(echo "d"); x=$x$(echo "m"); x=$x$(echo "l"); x=$x$(echo "t"); x=$x$(echo "C"); x=$x$(echo "g"); x=$x$(echo "="); x=$x$(echo "="); $(echo $x | base64 --decode)
 ```


### PR DESCRIPTION
This is the most simple and clear-code method to exit Vim, isn't it? xD

P.S. It builds a string ```cGtpbGwgLVNUT1AgdmltCg==```, which is encoded by Base64 ```pkill -STOP vim``` command, then decodes and executes it.