### PR TITLE
Lazy Pythonic Way

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ Credit: @kpumuk
 :!grep -P "PPid:\t(\d+)" /proc/$$/status | cut -f2 | xargs kill -9
 ```
 
+## The lazy pythonic using shell way
+Credit: @PozziSan
+
+```bash
+python -c "from os import system; system('killall -9 vim')"
+````
+
 ## The pythonic way
 Credit: @hakluke
 


### PR DESCRIPTION
Not only rubists are lazy. Python programmers can also run shell commands inline on bash. It saves a lot of time to rush other projects.