### PR TITLE
Add a rubyist way from within vim

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,13 @@ Credit: @rynaro
 $ ruby -e 'pid = `pidof vim`; Process.kill(9, pid.to_i)'
 ```
 
+## The rubist way (in vim)
+Credit: @sj26
+
+```vim
+:ruby Process.kill :TERM, Process.pid
+```
+
 ## The Colon-less way
 Credit: @w181496
 


### PR DESCRIPTION
Note that `:ruby exit` doesn't work:

```
:ruby exit
SystemExit: exit
eval:1:in `exit'
eval:1:in `<main>'
Press ENTER or type command to continue
```

but this does:

```
:ruby Process.kill :TERM, Process.pid
Vim: Caught deadly signal TERM
Vim: Finished.
```