### PR TITLE
Add missing backticks

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Credit: @aliva
  
 ```
 $ ps axuw | awk '{print $2}' | grep -v PID | shuf -n 1 | sudo kill -9
-
+```
 
 ## The "all against the odds" Russian Roulette way
 Credit: @cfrost


### PR DESCRIPTION
The backticks were probably left out mistakenly, which messed up markdown preview of the section.