### PR TITLE
The FlipperZero/BadUSB/Ducky way

### DIFF
--- a/README.md
+++ b/README.md
@@ -831,3 +831,16 @@ echo "pub fn main() !noreturn { unreachable; }" > vimkill.zig; zig build-exe vim
 ```
 
 This eventually [exhausts memory](https://github.com/ziglang/zig/issues/3461) on the machine which gives the OOM killer a chance to kill vim.
+
+## The Flipper Zero / BadUSB / Ducky Script way
+
+Credit: @0xphk
+
+```
+DELAY 1000
+ESCAPE
+DELAY 500
+STRING :q!
+DELAY 500
+ENTER
+```

--- a/README.md
+++ b/README.md
@@ -835,8 +835,9 @@ This eventually [exhausts memory](https://github.com/ziglang/zig/issues/3461) on
 ## The Flipper Zero / BadUSB / Ducky Script way 
 
 Credit: @0xphk
-* on FlipperZero, choose correct keyboard layout first (<config)
-* if using Duck Toolkit, set layout in settings
+* set correct keyboard layout in FlipperZero (<config)
+* if using Duck Toolkit, set keyboard layout in sidebar
+* if using PayloadStudio, set keyboard layout in settings
 * tested on FlipperZero and WHID Cactus
 ```
 DELAY 1000

--- a/README.md
+++ b/README.md
@@ -832,10 +832,12 @@ echo "pub fn main() !noreturn { unreachable; }" > vimkill.zig; zig build-exe vim
 
 This eventually [exhausts memory](https://github.com/ziglang/zig/issues/3461) on the machine which gives the OOM killer a chance to kill vim.
 
-## The Flipper Zero / BadUSB / Ducky Script way
+## The Flipper Zero / BadUSB / Ducky Script way 
 
 Credit: @0xphk
-
+* on FlipperZero, choose correct keyboard layout first (<config)
+* if using Duck Toolkit, set layout in settings
+* tested on FlipperZero and WHID Cactus
 ```
 DELAY 1000
 ESCAPE


### PR DESCRIPTION
Just close VIM using your beloved BadUSB device of choice

(tested w/ WHID Cactus, Flipper Zero)